### PR TITLE
[BugFix] fix env variable conflict due to svc geth-metrics

### DIFF
--- a/charts/geth/templates/service-metrics.yaml
+++ b/charts/geth/templates/service-metrics.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "geth.fullname" . }}-metrics
+  name: {{ include "geth.fullname" . }}-prom-metrics
   labels:
     {{- include "geth.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Context:
Log error when started: could not parse "tcp://<ip>:6060" as int value from environment variable "GETH_METRICS_PORT" for flag metrics.port: strconv.ParseInt: parsing "tcp://<ip>:6060": invalid syntax

GETH_METRICS_PORT env variable is used in geth to set the port of metrics endpoint. Supposed to be something like 6060 GETH_METRICS_PORT env variable was injected by kubernetes from the service geth-metrics. It injected something like tcp://<ip>:6060

Fix:
Rename the svc port to not have the conflict.